### PR TITLE
tcc_noticias: Inicio del Módulo de noticias

### DIFF
--- a/tcc_noticias/__openerp__.py
+++ b/tcc_noticias/__openerp__.py
@@ -26,6 +26,7 @@
     'data': [
         # 'security/ir.model.access.csv',
         'templates.xml',
+        'views/noticias_views.xml',
     ],
     # only loaded in demonstration mode
     'demo': [

--- a/tcc_noticias/models.py
+++ b/tcc_noticias/models.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-from openerp import models, fields, api
-
-# class tcc_noticias(models.Model):
-#     _name = 'tcc_noticias.tcc_noticias'
-
-#     name = fields.Char()

--- a/tcc_noticias/models/__init__.py
+++ b/tcc_noticias/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+import models

--- a/tcc_noticias/models/models.py
+++ b/tcc_noticias/models/models.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from openerp.osv import fields, osv
+
+
+class tcc_noticias(osv.osv):
+    _name = 'tcc.noticias'
+    _rec_name='titulo'
+    
+    _columns={
+		'consejo_id':fields.many2one(
+                    'tcc.consejocomunales',
+                    'Consejo Comunal',
+                    required=True,
+                    ondelete='cascade'
+                    ),
+		'categoria_id':fields.many2one(
+                    'tcc.noticias_categoria',
+                    'Categoria',
+                    required=True,
+                    ),
+        'titulo':fields.char('Título',help='Título de la noticia'),
+        'subtitulo':fields.char('Sub Título',help='Sub Título de la noticia'),
+        'fecha_init':fields.datetime('Fecha publicación',help='Fecha de publicación'),
+        'fecha_fin':fields.datetime('Fecha fin de la publicación',help='Fecha fin de la publicación'),
+        'cotenido':fields.html('Noticia'),
+        'active':fields.boolean('Activo',help='Si esta activo el motor lo incluira en la vista...'),
+        }
+        
+    _defaults={
+        'active':True
+        }
+        
+        
+class tcc_noticias_categoria(osv.osv):
+    _name = 'tcc.noticias_categoria'
+    _rec_name='name'
+    
+    _columns={
+        'name':fields.char('Nombre',required=True,help='Título de la noticia'),
+        'active':fields.boolean('Activo',help='Si esta activo el motor lo incluira en la vista...'),
+        }
+        
+    _defaults={
+        'active':True
+        }
+

--- a/tcc_noticias/views/noticias_views.xml
+++ b/tcc_noticias/views/noticias_views.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+ <data>
+     <record model="ir.ui.view" id="view_tcc_noticias_form">
+        <field name="name">vista form del formulario tcc.noticias </field>
+        <field name="model">tcc.noticias</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form string="Registro de la Noticia del Consejo Comunales">
+                <group>
+                    <field name="consejo_id" />
+                    <field name="titulo" />
+                    <field name="subtitulo" />
+                    <field name="categoria_id" />
+                    <field name="fecha_init" />
+                    <field name="fecha_fin" />
+                    <field name="cotenido" />
+                    <field name="active" />
+                </group>
+            </form>
+        </field>
+    </record>
+    
+    <record model="ir.ui.view" id="view_tcc_noticias_tree">
+        <field name="name">vista tree del formulario tcc.noticias</field>
+        <field name="model">tcc.noticias</field>
+        <field name="type">tree</field>
+        <field name="arch" type="xml">
+            <tree string="Registro de Consejo Comunales">
+                <field name="consejo_id"/>
+                <field name="titulo"/>
+                <field name="categoria_id"/>
+                <field name="fecha_init"/>
+            </tree>
+        </field>
+    </record>
+    
+    
+    <record model="ir.actions.act_window" id="action_tcc_noticias">
+        <field name="name">Gestión de Consejos Comunales</field>
+        <field name="res_model">tcc.noticias</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    
+    
+    <menuitem 
+        name="Gestión de Noticias" 
+        id="tcc_noticias_vertical_menu" 
+        parent="tcc_consejocomunales.tcc_consejocomunal_horizontal_menu" 
+        sequence="5"/>
+        
+    <menuitem 
+        name="Registros de Noticias" 
+        id="tcc_noticias_subvertical_menu" 
+        parent="tcc_noticias_vertical_menu"
+        action="action_tcc_noticias" 
+        sequence="5"/>
+
+ </data>
+</openerp>

--- a/tcc_vivienda/__openerp__.py
+++ b/tcc_vivienda/__openerp__.py
@@ -32,6 +32,6 @@
     ],
     # only loaded in demonstration mode
     'demo': [
-        'demo.xml',
+        'demo/demo.xml',
     ],
 }


### PR DESCRIPTION
[MOD] Se crearon las carpetas models para incluir aquí los archivos .py del módelo de noticias y views para .xml de la vistas

[ADD]  Se declaro el módelo de noticias compuesta por dos clases tcc_noticias  y tcc_noticias_categoria

[ADD] Se declaro la vista del módelo anteriormente descrito.