### PR TITLE
tcc_noticias: Roles de Usuarios

### DIFF
--- a/tcc_noticias/__openerp__.py
+++ b/tcc_noticias/__openerp__.py
@@ -25,8 +25,14 @@
     # always loaded
     'data': [
         # 'security/ir.model.access.csv',
+        'security/groups.xml',
+        'security/group_tcc_consejo/ir.model.access.csv',
+        'security/group_tcc_residentes/ir.model.access.csv',
+        'security/group_tcc_vocero/ir.model.access.csv',
+        'security/public/ir.model.access.csv',
         'templates.xml',
         'views/noticias_views.xml',
+        
     ],
     # only loaded in demonstration mode
     'demo': [

--- a/tcc_noticias/security/group_tcc_consejo/.~lock.ir.model.access.csv#
+++ b/tcc_noticias/security/group_tcc_consejo/.~lock.ir.model.access.csv#
@@ -1,0 +1,1 @@
+,felipe,jpablo,05.04.2017 19:23,file:///home/felipe/.config/libreoffice/4;

--- a/tcc_noticias/security/group_tcc_consejo/ir.model.access.csv
+++ b/tcc_noticias/security/group_tcc_consejo/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_tcc_noticias_tcc_noticias_group_tcc_consejo,tcc.noticias,tcc_noticias.model_tcc_noticias,tcc_noticias.group_tcc_consejo,1,1,1,0
+access_tcc_noticias_tcc_noticias_group_tcc_consejo,tcc.noticias_categoria,tcc_noticias.model_tcc_noticias_categoria,tcc_noticias.group_tcc_consejo,1,0,0,0

--- a/tcc_noticias/security/group_tcc_residentes/ir.model.access.csv
+++ b/tcc_noticias/security/group_tcc_residentes/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_tcc_noticias_tcc_noticias_group_tcc_residentes,tcc.noticias,tcc_noticias.model_tcc_noticias,tcc_noticias.group_tcc_residentes,1,0,0,0
+access_tcc_noticias_tcc_noticias_group_tcc_residentes,tcc.noticias_categoria,tcc_noticias.model_tcc_noticias_categoria,tcc_noticias.group_tcc_residentes,1,0,0,0

--- a/tcc_noticias/security/group_tcc_vocero/ir.model.access.csv
+++ b/tcc_noticias/security/group_tcc_vocero/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_tcc_noticias_tcc_noticias_group_tcc_vocero,tcc.noticias,tcc_noticias.model_tcc_noticias,tcc_noticias.group_tcc_vocero,1,1,1,0
+access_tcc_noticias_tcc_noticias_group_tcc_vocero,tcc.noticias_categoria,tcc_noticias.model_tcc_noticias_categoria,tcc_noticias.group_tcc_vocero,1,0,0,0

--- a/tcc_noticias/security/groups.xml
+++ b/tcc_noticias/security/groups.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<openerp>
+    <data>
+        <record id="group_tcc_consejo" model="res.groups">
+            <field name="name">Consejo Comunal</field>
+        </record>
+        <record id="group_tcc_vocero" model="res.groups">
+            <field name="name">Vocero</field>
+        </record>
+        <record id="group_tcc_residentes" model="res.groups">
+            <field name="name">Residente del Consejo Comunal</field>
+        </record>
+    </data>
+</openerp>

--- a/tcc_noticias/security/ir.model.access.csv
+++ b/tcc_noticias/security/ir.model.access.csv
@@ -1,2 +1,0 @@
-id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_tcc_noticias_tcc_noticias,tcc_noticias.tcc_noticias,model_tcc_noticias_tcc_noticias,,1,0,0,0

--- a/tcc_noticias/security/public/ir.model.access.csv
+++ b/tcc_noticias/security/public/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_tcc_noticias_tcc_noticias_publico,tcc.noticias,tcc_noticias.model_tcc_noticias,,1,0,0,0

--- a/tcc_noticias/views/noticias_views.xml
+++ b/tcc_noticias/views/noticias_views.xml
@@ -29,8 +29,8 @@
             <tree string="Registro de Consejo Comunales">
                 <field name="consejo_id"/>
                 <field name="titulo"/>
-                <field name="categoria_id"/>
-                <field name="fecha_init"/>
+                <field name="categoria_id" />
+                <field name="fecha_init" groups="tcc_noticias.group_tcc_vocero" />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
[ADD] Se declararon los roles de group_tcc_consejo, group_tcc_vocero y group_tcc_residentes.

[ADD] Se declaro los permisos para los roles antes descritos de los objetos de noticias.